### PR TITLE
Wrapped text in t()

### DIFF
--- a/Support/commands/schema/field.6.php
+++ b/Support/commands/schema/field.6.php
@@ -1,6 +1,6 @@
 '$1' => array(
   'type' => '$2',
-  'description' => '$3',
+  'description' => t('$3'),
   'default' => '${4:not null}',
   'not null' => ${5:TRUE},
 ),

--- a/Support/commands/schema/schema.6.php
+++ b/Support/commands/schema/schema.6.php
@@ -1,5 +1,5 @@
 \$schema['$1'] = array(
-  'description' => '$2',
+  'description' => t('$2'),
   'fields' => array(
     $3,
   ),


### PR DESCRIPTION
Minor change.

In the snippet used for fields in the schema, wrapped the description field in a t() call.
