### PR TITLE
fix hook_form_alter and hook_form_FORM_ID_alter

### DIFF
--- a/Support/commands/hooks/hook_form_FORM_ID_alter.6.php
+++ b/Support/commands/hooks/hook_form_FORM_ID_alter.6.php
@@ -1,7 +1,7 @@
 /**
  * Implementation of hook_form_FORM_ID_alter().
  */
-function <?php print $basename; ?>_form_FORM_ID_alter(&\$form, \$form_state) {${1:
+function <?php print $basename; ?>_form_FORM_ID_alter(&\$form, &\$form_state) {${1:
   ${2:// Form modification code goes here.}}
 }
 

--- a/Support/commands/hooks/hook_form_alter.6.php
+++ b/Support/commands/hooks/hook_form_alter.6.php
@@ -1,7 +1,7 @@
 /**
  * Implementation of hook_form_alter().
  */
-function <?php print $basename; ?>_form_alter(&\$form, \$form_state, \$form_id) {${1:
+function <?php print $basename; ?>_form_alter(&\$form, &\$form_state, \$form_id) {${1:
   switch (\$form_id) {
     case '${2:form_id}':
       ${3:// Form modification code goes here.}


### PR DESCRIPTION
hi, $form_state should pass by reference. Drupal API: http://api.drupal.org/api/function/hook_form_alter
