### PR TITLE
Trivial fix applied for drupal link syntax 

### DIFF
--- a/Snippets/l() user.tmSnippet
+++ b/Snippets/l() user.tmSnippet
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>content</key>
-	<string>&lt;?php print l(${1:\$user-&gt;name}, 'user/' . \$user-&gt;uid${2:, 'attributes' =&gt; array(${3:'class' =&gt; '${4:user-link}'})}); ?&gt;$0</string>
+	<string>&lt;?php print l(${1:\$user-&gt;name}, 'user/' . \$user-&gt;uid${2:, array('attributes' =&gt; array(${3:'class' =&gt; '${4:user-link}'})})); ?&gt;$0</string>
 	<key>name</key>
 	<string>&lt;?php l() user</string>
 	<key>scope</key>


### PR DESCRIPTION
Hi there,

First of all - thanks for sharing the php-drupal bundle for Textmate - I can't express how much it's eased the pain of drupal development since I started properly a few months back.

When using it to generated a link today in some code, I saw that the `l()` syntax for linking to user nodes was being spat out as `attributes` => array('class' => 'user-link')`, rather than`array('attributes' => array('class' => 'user-link'))`.

The commit I've added should spit out the fully wrapped array to avoid future errors.

Thanks again for such an amazing bundle!
