### PR TITLE
Fixed double '#type'

### DIFF
--- a/Support/commands/custom/fapi/controls/file.php
+++ b/Support/commands/custom/fapi/controls/file.php
@@ -2,6 +2,6 @@
   '#type' => 'file',
   '#title' => t('${1:File}'),
   '#description' => t('${2:Select the file you want to attach.}'),
-  '#type' => ${3:40},$4
+  '#weight' => ${3:40},$4
 );
 $5

--- a/Support/commands/custom/fapi/controls/file.php
+++ b/Support/commands/custom/fapi/controls/file.php
@@ -2,6 +2,6 @@
   '#type' => 'file',
   '#title' => t('${1:File}'),
   '#description' => t('${2:Select the file you want to attach.}'),
-  '#weight' => ${3:40},$4
+  '#size' => ${3:40},$4
 );
 $5


### PR DESCRIPTION
In the File fapi control, there were two '#type' keys. The second one should have been '#size'.
