### PR TITLE
Add more tab stops to hook_update_N()

### DIFF
--- a/Support/commands/overrides/hooks/6/hook_update_N.6.php
+++ b/Support/commands/overrides/hooks/6/hook_update_N.6.php
@@ -1,12 +1,12 @@
 /**
- * Implements hook_update_N().
+ * ${1:Implements hook_update_N().}
  */
-function <?php print $basename; ?>_update_${1:N}(&\$sandbox) {
+function <?php print $basename; ?>_update_${2:N}(${3:&\$sandbox}) {
   \$ret = array();
 
-  ${2:// Update code goes here.}
+  ${4:// Update code goes here.}
 
   return \$ret;
 }
 
-$3
+$5

--- a/Support/commands/overrides/hooks/7/hook_update_N.7.php
+++ b/Support/commands/overrides/hooks/7/hook_update_N.7.php
@@ -1,8 +1,8 @@
 /**
- * Implements hook_update_N().
+ * ${1:Implements hook_update_N().}
  */
-function <?php print $basename; ?>_update_N(&\$sandbox) {
-  ${1:// For non-multipass updates, the signature can simply be;
+function <?php print $basename; ?>_update_${2:N}(${3:&\$sandbox}) {
+  ${4:// For non-multipass updates, the signature can simply be;
   // function hook_update_N() {
 
   // For most updates, the following is sufficient.
@@ -48,4 +48,4 @@ function <?php print $basename; ?>_update_N(&\$sandbox) {
   throw new DrupalUpdateException('Something went wrong; here is what you should do.');}
 }
 
-$2
+$5


### PR DESCRIPTION
These commits add:
- A tab stop for the doxygen comment for this hook. It is generally recommended not to use the standard "Implements..." text, because this text is what is printed when the update is performed. It is usually set to something meaningful like "Update settings". I personally always want to change it, so I think a tab stop there would be good.
- A tab stop for the $sandbox parameter. I think it's safe to say that most update hooks are not multistep and putting a tab stop there would allow to easily delete that parameter for simplicity.

This is my first time trying to contribute to this project, so let me know if there's anything in terms of process I should do differently, or if you prefer things to come from d.o. I'm [goron](http://drupal.org/user/359162) on d.o.
